### PR TITLE
Use 3D noise for chunk generation

### DIFF
--- a/app/src/main/java/com/minecraftclone/App.java
+++ b/app/src/main/java/com/minecraftclone/App.java
@@ -19,13 +19,14 @@ public class App {
 
         World world = new World();
 
-        // Generate a single chunk using noise-based terrain heights.
+        // Generate a single chunk using 3D noise terrain.
         ChunkGenerator generator = new ChunkGenerator(seed);
-        generator.generate(world, 0, 0);
+        generator.generate(world, 0, 0, 0);
 
         int spawnX = Chunk.SIZE / 2;
         int spawnZ = Chunk.SIZE / 2;
-        int spawnY = generator.sampleHeight(spawnX, spawnZ) + 1;
+        int surface = generator.findSurfaceY(world, spawnX, spawnZ);
+        int spawnY = surface >= 0 ? surface + 1 : Chunk.SIZE;
         Player player = new Player(spawnX, spawnY, spawnZ);
         System.out.println("Player starting at " + player);
 

--- a/app/src/main/java/com/minecraftclone/ChunkGenerator.java
+++ b/app/src/main/java/com/minecraftclone/ChunkGenerator.java
@@ -1,7 +1,7 @@
 package com.minecraftclone;
 
 /**
- * Generates chunk terrain using a noise-based height map.
+ * Generates chunk terrain using 3D noise.
  */
 public class ChunkGenerator {
     private final NoiseGenerator noise;
@@ -23,38 +23,59 @@ public class ChunkGenerator {
     /**
      * Generates or fills the chunk at the given coordinates.
      */
-    public Chunk generate(World world, int cx, int cz) {
-        Chunk chunk = world.getChunk(cx, 0, cz);
+    public Chunk generate(World world, int cx, int cy, int cz) {
+        Chunk chunk = world.getChunk(cx, cy, cz);
         for (int x = 0; x < Chunk.SIZE; x++) {
-            for (int z = 0; z < Chunk.SIZE; z++) {
-                int wx = cx * Chunk.SIZE + x;
-                int wz = cz * Chunk.SIZE + z;
-                int height = sampleHeight(wx, wz);
-                for (int y = 0; y <= height; y++) {
-                    if (y == height) {
-                        chunk.setBlock(x, y, z, BlockType.GRASS);
-                    } else if (y >= height - 3) {
-                        chunk.setBlock(x, y, z, BlockType.DIRT);
-                    } else {
+            for (int y = 0; y < Chunk.SIZE; y++) {
+                for (int z = 0; z < Chunk.SIZE; z++) {
+                    int wx = cx * Chunk.SIZE + x;
+                    int wy = cy * Chunk.SIZE + y;
+                    int wz = cz * Chunk.SIZE + z;
+                    double n = noise.noise(wx * frequency, wy * frequency, wz * frequency);
+                    double density = n * amplitude;
+                    if (density > wy - baseHeight) {
                         chunk.setBlock(x, y, z, BlockType.STONE);
                     }
                 }
             }
         }
+
+        // Convert topmost stone blocks into grass/dirt layers.
+        for (int x = 0; x < Chunk.SIZE; x++) {
+            for (int z = 0; z < Chunk.SIZE; z++) {
+                for (int y = Chunk.SIZE - 1; y >= 0; y--) {
+                    if (chunk.getBlock(x, y, z) == BlockType.STONE) {
+                        chunk.setBlock(x, y, z, BlockType.GRASS);
+                        for (int d = 1; d <= 3 && y - d >= 0; d++) {
+                            if (chunk.getBlock(x, y - d, z) == BlockType.STONE) {
+                                chunk.setBlock(x, y - d, z, BlockType.DIRT);
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+
         return chunk;
     }
 
     /**
-     * Samples the terrain height at the given world coordinates.
+     * Finds the highest non-air block at the given world column within
+     * the generated chunks. Returns -1 if none found.
      */
-    public int sampleHeight(int wx, int wz) {
-        double n = noise.noise(wx * frequency, wz * frequency);
-        int height = (int) Math.round(baseHeight + n * amplitude);
-        if (height < 0) {
-            height = 0;
-        } else if (height >= Chunk.SIZE) {
-            height = Chunk.SIZE - 1;
+    public int findSurfaceY(World world, int wx, int wz) {
+        int cx = Math.floorDiv(wx, Chunk.SIZE);
+        int cz = Math.floorDiv(wz, Chunk.SIZE);
+        int x = Math.floorMod(wx, Chunk.SIZE);
+        int z = Math.floorMod(wz, Chunk.SIZE);
+        Chunk chunk = world.getChunk(cx, 0, cz);
+        for (int y = Chunk.SIZE - 1; y >= 0; y--) {
+            if (chunk.getBlock(x, y, z) != BlockType.AIR) {
+                return y;
+            }
         }
-        return height;
+        return -1;
     }
 }
+

--- a/app/src/main/java/com/minecraftclone/NoiseGenerator.java
+++ b/app/src/main/java/com/minecraftclone/NoiseGenerator.java
@@ -3,7 +3,7 @@ package com.minecraftclone;
 import java.util.Random;
 
 /**
- * Simple 2D Perlin noise generator.
+ * Simple 3D Perlin noise generator.
  */
 public class NoiseGenerator {
     private final int[] p = new int[512];
@@ -25,20 +25,43 @@ public class NoiseGenerator {
         }
     }
 
+    /** Convenience overload that assumes z=0. */
     public double noise(double x, double y) {
+        return noise(x, y, 0);
+    }
+
+    /**
+     * Generates 3D Perlin noise in the range [-1, 1].
+     */
+    public double noise(double x, double y, double z) {
         int xi = (int) Math.floor(x) & 255;
         int yi = (int) Math.floor(y) & 255;
+        int zi = (int) Math.floor(z) & 255;
         double xf = x - Math.floor(x);
         double yf = y - Math.floor(y);
+        double zf = z - Math.floor(z);
         double u = fade(xf);
         double v = fade(yf);
-        int aa = p[p[xi] + yi];
-        int ab = p[p[xi] + yi + 1];
-        int ba = p[p[xi + 1] + yi];
-        int bb = p[p[xi + 1] + yi + 1];
-        double x1 = lerp(grad(aa, xf, yf), grad(ba, xf - 1, yf), u);
-        double x2 = lerp(grad(ab, xf, yf - 1), grad(bb, xf - 1, yf - 1), u);
-        return lerp(x1, x2, v);
+        double w = fade(zf);
+
+        int aaa = p[p[p[xi] + yi] + zi];
+        int aba = p[p[p[xi] + yi + 1] + zi];
+        int aab = p[p[p[xi] + yi] + zi + 1];
+        int abb = p[p[p[xi] + yi + 1] + zi + 1];
+        int baa = p[p[p[xi + 1] + yi] + zi];
+        int bba = p[p[p[xi + 1] + yi + 1] + zi];
+        int bab = p[p[p[xi + 1] + yi] + zi + 1];
+        int bbb = p[p[p[xi + 1] + yi + 1] + zi + 1];
+
+        double x1 = lerp(grad(aaa, xf, yf, zf), grad(baa, xf - 1, yf, zf), u);
+        double x2 = lerp(grad(aba, xf, yf - 1, zf), grad(bba, xf - 1, yf - 1, zf), u);
+        double y1 = lerp(x1, x2, v);
+
+        double x3 = lerp(grad(aab, xf, yf, zf - 1), grad(bab, xf - 1, yf, zf - 1), u);
+        double x4 = lerp(grad(abb, xf, yf - 1, zf - 1), grad(bbb, xf - 1, yf - 1, zf - 1), u);
+        double y2 = lerp(x3, x4, v);
+
+        return lerp(y1, y2, w);
     }
 
     private double fade(double t) {
@@ -49,12 +72,10 @@ public class NoiseGenerator {
         return a + t * (b - a);
     }
 
-    private double grad(int hash, double x, double y) {
-        switch (hash & 3) {
-            case 0: return x + y;
-            case 1: return -x + y;
-            case 2: return x - y;
-            default: return -x - y;
-        }
+    private double grad(int hash, double x, double y, double z) {
+        int h = hash & 15;
+        double u = h < 8 ? x : y;
+        double v = h < 4 ? y : h == 12 || h == 14 ? x : z;
+        return ((h & 1) == 0 ? u : -u) + ((h & 2) == 0 ? v : -v);
     }
 }


### PR DESCRIPTION
## Summary
- add full 3D Perlin noise generator
- generate chunk blocks from 3D noise instead of a 2D heightmap
- compute player spawn using surface lookup in generated world

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c4703dab34832484e73f717e0487df