### PR TITLE
Search surface across vertical chunks

### DIFF
--- a/app/src/main/java/com/minecraftclone/App.java
+++ b/app/src/main/java/com/minecraftclone/App.java
@@ -32,9 +32,8 @@ public class App {
         int centerChunk = 16 / 2;
         int spawnX = centerChunk * Chunk.SIZE + Chunk.SIZE / 2;
         int spawnZ = centerChunk * Chunk.SIZE + Chunk.SIZE / 2;
-        int surface = generator.findSurfaceY(world, spawnX, spawnZ);
-        int spawnY = surface >= 0 ? surface + 1 : Chunk.SIZE;
-        Player player = new Player(spawnX, spawnY, spawnZ);
+        int surfaceY = generator.findSurfaceY(world, spawnX, spawnZ);
+        Player player = new Player(spawnX, surfaceY + 1, spawnZ);
         System.out.println("Player starting at " + player);
 
         // Launch the LWJGL-based renderer.

--- a/app/src/main/java/com/minecraftclone/ChunkGenerator.java
+++ b/app/src/main/java/com/minecraftclone/ChunkGenerator.java
@@ -1,5 +1,9 @@
 package com.minecraftclone;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 /**
  * Generates chunk terrain using 3D noise.
  */
@@ -69,10 +73,24 @@ public class ChunkGenerator {
         int cz = Math.floorDiv(wz, Chunk.SIZE);
         int x = Math.floorMod(wx, Chunk.SIZE);
         int z = Math.floorMod(wz, Chunk.SIZE);
-        Chunk chunk = world.getChunk(cx, 0, cz);
-        for (int y = Chunk.SIZE - 1; y >= 0; y--) {
-            if (chunk.getBlock(x, y, z) != BlockType.AIR) {
-                return y;
+
+        List<Integer> ys = new ArrayList<>();
+        for (ChunkPos pos : world.getChunkPositions()) {
+            if (pos.x() == cx && pos.z() == cz) {
+                ys.add(pos.y());
+            }
+        }
+        if (ys.isEmpty()) {
+            return -1;
+        }
+        Collections.sort(ys);
+        for (int i = ys.size() - 1; i >= 0; i--) {
+            int cy = ys.get(i);
+            Chunk chunk = world.getChunk(cx, cy, cz);
+            for (int y = Chunk.SIZE - 1; y >= 0; y--) {
+                if (chunk.getBlock(x, y, z) != BlockType.AIR) {
+                    return cy * Chunk.SIZE + y;
+                }
             }
         }
         return -1;

--- a/app/src/main/java/com/minecraftclone/World.java
+++ b/app/src/main/java/com/minecraftclone/World.java
@@ -2,6 +2,8 @@ package com.minecraftclone;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Collections;
+import java.util.Set;
 
 /**
  * Represents the game world as a set of chunks.
@@ -14,6 +16,13 @@ public class World {
      */
     public Chunk getChunk(int cx, int cy, int cz) {
         return chunks.computeIfAbsent(new ChunkPos(cx, cy, cz), pos -> new Chunk());
+    }
+
+    /**
+     * Returns the set of positions for currently loaded chunks.
+     */
+    public Set<ChunkPos> getChunkPositions() {
+        return Collections.unmodifiableSet(chunks.keySet());
     }
 
     /**


### PR DESCRIPTION
## Summary
- Scan vertical chunk stack in `findSurfaceY` to locate the highest solid block using existing chunk positions.
- Expose loaded chunk positions from `World` to support surface lookup.
- Spawn player above the true terrain surface using the updated method.

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c476344710832489f0d8a36d025493