### PR TITLE
Generate chunks on demand around the player

### DIFF
--- a/app/src/main/java/com/minecraftclone/App.java
+++ b/app/src/main/java/com/minecraftclone/App.java
@@ -17,21 +17,19 @@ public class App {
         }
         System.out.println("Using seed: " + seed);
 
-        World world = new World();
-
-        // Generate a grid of chunks using 3D noise terrain.
         ChunkGenerator generator = new ChunkGenerator(seed);
-        for (int cx = 0; cx < 16; cx++) {
-            for (int cy = 0; cy < 16; cy++) {
-                for (int cz = 0; cz < 16; cz++) {
-                    generator.generate(world, cx, cy, cz);
-                }
-            }
+        World world = new World(generator);
+
+        // Generate a small column of chunks at the spawn location so we can
+        // find a reasonable starting Y coordinate.
+        int spawnChunkX = 0;
+        int spawnChunkZ = 0;
+        for (int cy = -1; cy <= 1; cy++) {
+            world.getChunk(spawnChunkX, cy, spawnChunkZ);
         }
 
-        int centerChunk = 16 / 2;
-        int spawnX = centerChunk * Chunk.SIZE + Chunk.SIZE / 2;
-        int spawnZ = centerChunk * Chunk.SIZE + Chunk.SIZE / 2;
+        int spawnX = spawnChunkX * Chunk.SIZE + Chunk.SIZE / 2;
+        int spawnZ = spawnChunkZ * Chunk.SIZE + Chunk.SIZE / 2;
         int surfaceY = generator.findSurfaceY(world, spawnX, spawnZ);
         Player player = new Player(spawnX, surfaceY + 1, spawnZ);
         System.out.println("Player starting at " + player);

--- a/app/src/main/java/com/minecraftclone/World.java
+++ b/app/src/main/java/com/minecraftclone/World.java
@@ -10,12 +10,27 @@ import java.util.Set;
  */
 public class World {
     private final Map<ChunkPos, Chunk> chunks = new HashMap<>();
+    private final ChunkGenerator generator;
+
+    public World(ChunkGenerator generator) {
+        this.generator = generator;
+    }
 
     /**
-     * Retrieves a chunk at the given chunk coordinates, creating it if necessary.
+     * Retrieves a chunk at the given chunk coordinates, creating and generating it
+     * if necessary.
      */
     public Chunk getChunk(int cx, int cy, int cz) {
-        return chunks.computeIfAbsent(new ChunkPos(cx, cy, cz), pos -> new Chunk());
+        ChunkPos pos = new ChunkPos(cx, cy, cz);
+        Chunk chunk = chunks.get(pos);
+        if (chunk == null) {
+            chunk = new Chunk();
+            chunks.put(pos, chunk);
+            if (generator != null) {
+                generator.generate(this, cx, cy, cz);
+            }
+        }
+        return chunk;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Generate new chunks lazily when first requested, backed by a `ChunkGenerator` instance in `World`
- Initialize world with a generator and pre-build only the spawn column, letting movement trigger chunk creation

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68c4789d4e3483248fef6759ecbbf0ac