### PR TITLE
Implement chunk occlusion culling using OpenGL queries

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,6 +25,8 @@ dependencies {
     runtimeOnly("org.lwjgl:lwjgl-glfw::$lwjglNatives")
     runtimeOnly("org.lwjgl:lwjgl-opengl::$lwjglNatives")
 
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.0")
 }
 
 java {
@@ -35,4 +37,8 @@ java {
 
 application {
     mainClass = "com.minecraftclone.App"
+}
+
+tasks.test {
+    useJUnitPlatform()
 }

--- a/app/src/main/java/com/minecraftclone/App.java
+++ b/app/src/main/java/com/minecraftclone/App.java
@@ -71,7 +71,8 @@ public class App {
         int spawnX = spawnChunkX * Chunk.SIZE + Chunk.SIZE / 2;
         int spawnZ = spawnChunkZ * Chunk.SIZE + Chunk.SIZE / 2;
         int surfaceY = generator.findSurfaceY(world, spawnX, spawnZ);
-        Player player = new Player(spawnX, surfaceY + 1, spawnZ);
+        // Start the player slightly above ground to avoid spawning inside blocks.
+        Player player = new Player(spawnX, surfaceY + 2, spawnZ);
         System.out.println("Player starting at " + player);
 
         // Launch the LWJGL-based renderer.

--- a/app/src/main/java/com/minecraftclone/WorldRenderer.java
+++ b/app/src/main/java/com/minecraftclone/WorldRenderer.java
@@ -423,18 +423,19 @@ public class WorldRenderer {
         float y2 = baseY + Chunk.SIZE;
         float z2 = baseZ + Chunk.SIZE;
         glBegin(GL_QUADS);
-        // +X
+        // Faces wound counter-clockwise so front sides point outward
+        // +X face
         glVertex3f(x2, y1, z1); glVertex3f(x2, y2, z1); glVertex3f(x2, y2, z2); glVertex3f(x2, y1, z2);
-        // -X
+        // -X face
         glVertex3f(x1, y1, z2); glVertex3f(x1, y2, z2); glVertex3f(x1, y2, z1); glVertex3f(x1, y1, z1);
-        // +Y
-        glVertex3f(x1, y2, z1); glVertex3f(x2, y2, z1); glVertex3f(x2, y2, z2); glVertex3f(x1, y2, z2);
-        // -Y
-        glVertex3f(x1, y1, z2); glVertex3f(x2, y1, z2); glVertex3f(x2, y1, z1); glVertex3f(x1, y1, z1);
-        // +Z
-        glVertex3f(x1, y1, z2); glVertex3f(x1, y2, z2); glVertex3f(x2, y2, z2); glVertex3f(x2, y1, z2);
-        // -Z
-        glVertex3f(x2, y1, z1); glVertex3f(x2, y2, z1); glVertex3f(x1, y2, z1); glVertex3f(x1, y1, z1);
+        // +Y face
+        glVertex3f(x1, y2, z1); glVertex3f(x1, y2, z2); glVertex3f(x2, y2, z2); glVertex3f(x2, y2, z1);
+        // -Y face
+        glVertex3f(x1, y1, z1); glVertex3f(x2, y1, z1); glVertex3f(x2, y1, z2); glVertex3f(x1, y1, z2);
+        // +Z face
+        glVertex3f(x1, y1, z2); glVertex3f(x2, y1, z2); glVertex3f(x2, y2, z2); glVertex3f(x1, y2, z2);
+        // -Z face
+        glVertex3f(x1, y1, z1); glVertex3f(x1, y2, z1); glVertex3f(x2, y2, z1); glVertex3f(x2, y1, z1);
         glEnd();
     }
 

--- a/app/src/main/java/com/minecraftclone/WorldRenderer.java
+++ b/app/src/main/java/com/minecraftclone/WorldRenderer.java
@@ -279,7 +279,9 @@ public class WorldRenderer {
                 glBeginQuery(GL_SAMPLES_PASSED, query);
                 glColorMask(false, false, false, false);
                 glDepthMask(false);
+                glDepthFunc(GL_LEQUAL);
                 renderBoundingBox(baseX, baseY, baseZ);
+                glDepthFunc(GL_LESS);
                 glDepthMask(true);
                 glColorMask(true, true, true, true);
                 glEndQuery(GL_SAMPLES_PASSED);

--- a/app/src/main/java/com/minecraftclone/WorldRenderer.java
+++ b/app/src/main/java/com/minecraftclone/WorldRenderer.java
@@ -229,6 +229,10 @@ public class WorldRenderer {
             int baseZ = cz * Chunk.SIZE;
             if (!boxInFrustum(baseX, baseY, baseZ,
                     baseX + Chunk.SIZE, baseY + Chunk.SIZE, baseZ + Chunk.SIZE)) {
+                Chunk chunk = world.getChunkIfLoaded(cx, cy, cz);
+                if (chunk != null) {
+                    chunkVisibility.remove(chunk);
+                }
                 continue;
             }
             Chunk chunk = world.getChunkIfLoaded(cx, cy, cz);

--- a/app/src/main/java/com/minecraftclone/WorldRenderer.java
+++ b/app/src/main/java/com/minecraftclone/WorldRenderer.java
@@ -206,7 +206,7 @@ public class WorldRenderer {
         }
         positions.sort(Comparator.comparingInt(p -> p[3]));
 
-        // Depth prepass rendering bounding boxes
+        // Depth prepass rendering bounding boxes of loaded chunks with meshes
         glColorMask(false, false, false, false);
         for (int[] p : positions) {
             int cx = p[0];
@@ -219,7 +219,8 @@ public class WorldRenderer {
                     baseX + Chunk.SIZE, baseY + Chunk.SIZE, baseZ + Chunk.SIZE)) {
                 continue;
             }
-            if (world.isChunkOccluded(cx, cy, cz)) {
+            Chunk chunk = world.getChunkIfLoaded(cx, cy, cz);
+            if (chunk == null || chunk.isOccluded() || chunk.getMesh() == null) {
                 continue;
             }
             renderBoundingBox(baseX, baseY, baseZ);

--- a/app/src/test/java/com/minecraftclone/OcclusionDebugStatsTest.java
+++ b/app/src/test/java/com/minecraftclone/OcclusionDebugStatsTest.java
@@ -1,0 +1,22 @@
+package com.minecraftclone;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class OcclusionDebugStatsTest {
+    @Test
+    public void testRecordAndReset() {
+        WorldRenderer.OcclusionDebugStats stats = new WorldRenderer.OcclusionDebugStats();
+        stats.recordResult(true);
+        stats.recordResult(false);
+        stats.recordPending();
+        assertEquals(1, stats.visible);
+        assertEquals(1, stats.occluded);
+        assertEquals(1, stats.pending);
+        stats.reset();
+        assertEquals(0, stats.visible);
+        assertEquals(0, stats.occluded);
+        assertEquals(0, stats.pending);
+    }
+}


### PR DESCRIPTION
## Summary
- Render chunk bounding boxes in a depth-only prepass
- Add per-chunk occlusion queries and skip meshes with zero visible samples
- Manage OpenGL query objects during renderer lifecycle

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c61b3d24b88324a92d3ec8c30d295d