### PR TITLE
Add chunk occlusion queries with depth prepass

### DIFF
--- a/app/src/main/java/com/minecraftclone/Chunk.java
+++ b/app/src/main/java/com/minecraftclone/Chunk.java
@@ -24,6 +24,10 @@ public class Chunk {
     private final boolean[] solidFaces = new boolean[6];
     /** Whether this chunk is completely hidden by neighbors. */
     private boolean occluded;
+    /** OpenGL occlusion query object for this chunk. */
+    private int queryId;
+    /** Cached visibility result from the last completed query. */
+    private boolean visible = true;
 
     public Chunk() {
         // initialize all blocks to AIR
@@ -208,6 +212,22 @@ public class Chunk {
 
     public void setOccluded(boolean occluded) {
         this.occluded = occluded;
+    }
+
+    public int getQueryId() {
+        return queryId;
+    }
+
+    public void setQueryId(int queryId) {
+        this.queryId = queryId;
+    }
+
+    public boolean isVisible() {
+        return visible;
+    }
+
+    public void setVisible(boolean visible) {
+        this.visible = visible;
     }
 
     private void check(int x, int y, int z) {


### PR DESCRIPTION
## Summary
- Build axis-aligned bounding boxes for chunks and draw them in a depth-only prepass
- Wrap chunk mesh rendering with GL_SAMPLES_PASSED queries and skip invisible chunks
- Track and clean up OpenGL query objects for each chunk

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68c626cf43008324b946e32de0358937