### PR TITLE
Add C++ BlockType example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ build
 
 # Ignore generated world data
 world/
+
+# Ignore C++ build artifacts
+cpp/*.o
+cpp/test_blocktype

--- a/cpp/BlockType.hpp
+++ b/cpp/BlockType.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+// Basic block types supported by the toy Minecraft clone.
+// Ported from the Java version.
+
+enum class BlockType : char {
+    Air   = ' ',
+    Dirt  = 'D',
+    Grass = 'G',
+    Stone = 'S',
+    Sand  = 'A',
+    Water = 'W',
+    Snow  = 'N',
+    Ice   = 'I'
+};
+
+inline char getDisplay(BlockType type) {
+    return static_cast<char>(type);
+}

--- a/cpp/main.cpp
+++ b/cpp/main.cpp
@@ -1,0 +1,8 @@
+#include <iostream>
+#include "BlockType.hpp"
+
+int main() {
+    BlockType block = BlockType::Grass;
+    std::cout << getDisplay(block) << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Port Java BlockType enum to a C++ `enum class` with helper to retrieve display character
- Provide a simple `main.cpp` demonstrating usage
- Ignore C++ build artifacts

## Testing
- `g++ -std=c++17 cpp/main.cpp -o cpp/test_blocktype`
- `cpp/test_blocktype`

------
https://chatgpt.com/codex/tasks/task_e_68c82d3a4ee88324a22722194af32f2e